### PR TITLE
Don't append to a buffer you don't own

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -97,7 +97,10 @@ func (s dhkemScheme) Encap(rand io.Reader, pkR KEMPublicKey) ([]byte, []byte, er
 
 	enc := s.group.Marshal(pkE)
 	pkRm := s.group.Marshal(pkR)
-	kemContext := append(enc, pkRm...)
+
+	kemContext := make([]byte, len(enc)+len(pkRm))
+	copy(kemContext, enc)
+	copy(kemContext[len(enc):], pkRm)
 
 	Nzz := s.SharedSecretSize()
 	zz := s.extractAndExpand(dh, kemContext, Nzz)
@@ -117,7 +120,10 @@ func (s dhkemScheme) Decap(enc []byte, skR KEMPrivateKey) ([]byte, error) {
 	}
 
 	pkRm := s.group.Marshal(skR.PublicKey())
-	kemContext := append(enc, pkRm...)
+
+	kemContext := make([]byte, len(enc)+len(pkRm))
+	copy(kemContext, enc)
+	copy(kemContext[len(enc):], pkRm)
 
 	Nzz := s.SharedSecretSize()
 	zz := s.extractAndExpand(dh, kemContext, Nzz)


### PR DESCRIPTION
Appending to the `enc` buffer provided by the caller causes problems when the buffer has extra capacity beyond its len, but the data in that extra capacity is owned by other code.  This situation can arise due to in-place decoders, as proposed for the TLS-syntax in https://github.com/cisco/go-tls-syntax/pull/1.  (Go does not have a way to shrink a slices capacity, unfortunately.)