### PR TITLE
Update the test vector format script to use the new KeyScheduleContext name.

### DIFF
--- a/format_vectors.py
+++ b/format_vectors.py
@@ -5,7 +5,7 @@ import textwrap
 ordered_keys = [
     "mode", "kemID", "kdfID", "aeadID", "info", "skRm",
     "skSm", "skEm", "psk", "pskID", "pkRm", "pkSm", "pkEm",
-    "enc", "zz", "context", "secret", "key", "nonce",
+    "enc", "zz", "key_schedule_context", "secret", "key", "nonce",
     "exporterSecret",
 ]
 


### PR DESCRIPTION
This was a small oversight in the previous PR (#27). 