### PR TITLE
Fixed PSK ID hash context string

### DIFF
--- a/hpke.go
+++ b/hpke.go
@@ -163,7 +163,7 @@ func keySchedule(suite CipherSuite, mode Mode, zz, info, psk, pskID []byte) (con
 	}
 
 	suiteID := suite.ID()
-	pskIDHash := suite.KDF.LabeledExtract(nil, suiteID, "pskID_hash", pskID)
+	pskIDHash := suite.KDF.LabeledExtract(nil, suiteID, "psk_id_hash", pskID)
 	infoHash := suite.KDF.LabeledExtract(nil, suiteID, "info_hash", info)
 
 	contextStruct := hpkeContext{mode, pskIDHash, infoHash}


### PR DESCRIPTION
The context string was changed in https://github.com/cfrg/draft-irtf-cfrg-hpke/commit/fc0f59bf2f8c19b1a4275e06d49cc206b2d0d583 .

Test vectors need to be recomputed.