### PR TITLE
Use the x-coordinate as DH shared secret for NIST curves.

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -336,8 +336,12 @@ func (s ecdhScheme) DH(priv KEMPrivateKey, pub KEMPublicKey) ([]byte, error) {
 		return nil, fmt.Errorf("Public key not suitable for ECDH")
 	}
 
-	x, y := s.curve.Params().ScalarMult(ecdhPub.x, ecdhPub.y, ecdhPriv.d)
-	dh := elliptic.Marshal(ecdhPub.curve, x, y)
+	x, _ := s.curve.Params().ScalarMult(ecdhPub.x, ecdhPub.y, ecdhPriv.d)
+	xx := x.Bytes()
+
+	size := (s.curve.Params().BitSize + 7) >> 3
+	pad := make([]byte, size-len(xx))
+	dh := append(pad, xx...)
 
 	return dh, nil
 }
@@ -443,7 +447,6 @@ func (s x25519Scheme) DH(priv KEMPrivateKey, pub KEMPublicKey) ([]byte, error) {
 		return nil, fmt.Errorf("Private key not suitable for X25519")
 	}
 
-	// TODO ScalarMult
 	var sharedSecret [32]byte
 	curve25519.ScalarMult(&sharedSecret, &xPriv.val, &xPub.val)
 	return sharedSecret[:], nil

--- a/format_vectors.py
+++ b/format_vectors.py
@@ -85,6 +85,7 @@ testSuites = [
     CipherSuite(kem_idX25519, kdf_idSHA256, aead_idAES128GCM),
     CipherSuite(kem_idX25519, kdf_idSHA256, aead_idChaCha20Poly1305),
     CipherSuite(kem_idP256, kdf_idSHA256, aead_idAES128GCM),
+    CipherSuite(kem_idP256, kdf_idSHA512, aead_idAES128GCM),
     CipherSuite(kem_idP256, kdf_idSHA256, aead_idChaCha20Poly1305),
     CipherSuite(kem_idP521, kdf_idSHA512, aead_idAES256GCM),
 ]


### PR DESCRIPTION
And add one new ciphersuite variant with different DHKEM and HPKE KDFs.