### PR TITLE
Pin the version label to "HPKE-v1".

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -878,7 +878,7 @@ func (s hkdfScheme) Expand(prk, info []byte, outLen int) []byte {
 }
 
 func (s hkdfScheme) LabeledExtract(salt []byte, suiteID []byte, label string, ikm []byte) []byte {
-	labeledIKM := append([]byte(rfcLabel), suiteID...)
+	labeledIKM := append([]byte(versionLabel), suiteID...)
 	labeledIKM = append(labeledIKM, []byte(label)...)
 	labeledIKM = append(labeledIKM, ikm...)
 	return s.Extract(salt, labeledIKM)
@@ -891,7 +891,7 @@ func (s hkdfScheme) LabeledExpand(prk []byte, suiteID []byte, label string, info
 
 	lengthBuffer := make([]byte, 2)
 	binary.BigEndian.PutUint16(lengthBuffer, uint16(L))
-	labeledLength := append(lengthBuffer, []byte(rfcLabel)...)
+	labeledLength := append(lengthBuffer, []byte(versionLabel)...)
 	labeledInfo := append(labeledLength, suiteID...)
 	labeledInfo = append(labeledInfo, []byte(label)...)
 	labeledInfo = append(labeledInfo, info...)

--- a/hpke.go
+++ b/hpke.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	debug    = true
-	rfcLabel = "HPKE-07"
+	debug        = true
+	versionLabel = "HPKE-v1"
 )
 
 type KEMPrivateKey interface {


### PR DESCRIPTION
See [the corresponding draft change](https://github.com/cfrg/draft-irtf-cfrg-hpke/pull/204).