### PR TITLE
Convert NIST public key serialization to "compact representation"

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13'
+          go-version: '1.15'
       
       - name: Check out code
         uses: actions/checkout@v2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cisco/go-hpke
 
-go 1.14
+go 1.15
 
 require (
 	git.schwanenlied.me/yawning/x448.git v0.0.0-20170617130356-01b048fb03d6


### PR DESCRIPTION
Per RFC6090, this is simply the x coordinate. The y coordinate sign bit is ignored when deserializing, as it does not affect the DH shared secret output.