### PR TITLE
Rename encryption test vector fields to align with spec.

### DIFF
--- a/format_vectors.py
+++ b/format_vectors.py
@@ -15,7 +15,7 @@ ordered_keys = [
 ]
 
 ordered_encryption_keys = [
-    "plaintext", "aad", "nonce", "ciphertext",
+    "pt", "aad", "nonce", "ct",
 ]
 
 ordered_export_keys = [

--- a/hpke_test.go
+++ b/hpke_test.go
@@ -146,10 +146,10 @@ type encryptionTestVector struct {
 
 func (etv encryptionTestVector) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]string{
-		"plaintext":  mustHex(etv.plaintext),
-		"aad":        mustHex(etv.aad),
-		"nonce":      mustHex(etv.nonce),
-		"ciphertext": mustHex(etv.ciphertext),
+		"pt":    mustHex(etv.plaintext),
+		"aad":   mustHex(etv.aad),
+		"nonce": mustHex(etv.nonce),
+		"ct":    mustHex(etv.ciphertext),
 	})
 }
 
@@ -160,10 +160,10 @@ func (etv *encryptionTestVector) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	etv.plaintext = mustUnhex(nil, raw["plaintext"])
+	etv.plaintext = mustUnhex(nil, raw["pt"])
 	etv.aad = mustUnhex(nil, raw["aad"])
 	etv.nonce = mustUnhex(nil, raw["nonce"])
-	etv.ciphertext = mustUnhex(nil, raw["ciphertext"])
+	etv.ciphertext = mustUnhex(nil, raw["ct"])
 	return nil
 }
 


### PR DESCRIPTION
The spec uses `pt` to denote plaintext, whereas the vectors used `plaintext`. Unify around `pt` et al.