### PR TITLE
Remove SIKE

### DIFF
--- a/crypto_test.go
+++ b/crypto_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rand"
 	"testing"
 
-	"github.com/cloudflare/circl/dh/sidh"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,8 +21,6 @@ func TestKEMSchemes(t *testing.T) {
 		&dhkemScheme{group: x448Scheme{}},
 		&dhkemScheme{group: ecdhScheme{curve: elliptic.P256(), KDF: hkdfScheme{hash: crypto.SHA256}}},
 		&dhkemScheme{group: ecdhScheme{curve: elliptic.P521(), KDF: hkdfScheme{hash: crypto.SHA256}}},
-		&sikeScheme{field: sidh.Fp503, KDF: hkdfScheme{hash: crypto.SHA512}},
-		&sikeScheme{field: sidh.Fp751, KDF: hkdfScheme{hash: crypto.SHA512}},
 	}
 
 	for i, s := range schemes {


### PR DESCRIPTION
SIKE was a fine prototype to demonstrate API compatibility with PQ KEM, but now [it's broken](https://eprint.iacr.org/2022/975.pdf).  We should remove SIKE so that nobody uses it by accident.